### PR TITLE
chore: GRS wireup - add initial scoring and features stubs

### DIFF
--- a/src/growthbrief/scoring.py
+++ b/src/growthbrief/scoring.py
@@ -1,0 +1,6 @@
+import pandas as pd
+
+def score_grs(df: pd.DataFrame) -> pd.DataFrame:
+    """Stub for Growth Room Score (GRS) calculation."""
+    # TODO: Implement GRS calculation
+    return df

--- a/tests/growthbrief/test_scoring_smoke.py
+++ b/tests/growthbrief/test_scoring_smoke.py
@@ -1,0 +1,17 @@
+import pandas as pd
+from growthbrief.scoring import score_grs
+
+def test_score_grs_smoke():
+    # Create a dummy DataFrame for smoke test
+    data = {
+        'col1': [1, 2, 3],
+        'col2': [4, 5, 6]
+    }
+    df = pd.DataFrame(data)
+
+    # Call the function
+    result_df = score_grs(df)
+
+    # Assert that the result is a DataFrame and has the expected columns (for now, just the original ones)
+    assert isinstance(result_df, pd.DataFrame)
+    assert list(result_df.columns) == list(df.columns)


### PR DESCRIPTION
What changed + why: Added initial stubs for GRS scoring and features to wire up the project structure.\nAcceptance checks:\n- Created `src/growthbrief/features/__init__.py`\n- Created `src/growthbrief/scoring.py` with `score_grs(df)` signature.\n- Created `tests/growthbrief/test_scoring_smoke.py` placeholder.\nTODOs: Implementation of GRS calculation in `score_grs` and actual tests for scoring.