### PR TITLE
feat: fundamentals-fm-v1 - implement fundamentals_snapshot

### DIFF
--- a/src/growthbrief/features/fundamentals.py
+++ b/src/growthbrief/features/fundamentals.py
@@ -1,0 +1,93 @@
+import yfinance as yf
+import pandas as pd
+import numpy as np
+
+def fundamentals_snapshot(ticker: str) -> dict:
+    """
+    Fetches key fundamental data for a given ticker using yfinance.
+
+    Args:
+        ticker: The stock ticker symbol (e.g., "AAPL").
+
+    Returns:
+        A dictionary containing fundamental metrics, or NaN for missing data.
+    """
+    try:
+        stock = yf.Ticker(ticker)
+
+        # Fetch financial data
+        income_stmt = stock.financials
+        cash_flow = stock.cashflow
+        balance_sheet = stock.balance_sheet
+
+        # Ensure dataframes are not empty and are in the expected format (columns are dates)
+        if income_stmt.empty or cash_flow.empty or balance_sheet.empty:
+            return {
+                'rev_yoy': np.nan,
+                'gm': np.nan, 'gm_delta': np.nan,
+                'om': np.nan, 'om_delta': np.nan,
+                'fcf_margin': np.nan, 'fcf_delta': np.nan,
+                'accruals_proxy': np.nan
+            }
+
+        # Align dataframes by date (most recent first)
+        income_stmt = income_stmt.T.sort_index(ascending=False)
+        cash_flow = cash_flow.T.sort_index(ascending=False)
+        balance_sheet = balance_sheet.T.sort_index(ascending=False)
+
+        # --- Revenue YoY ---
+        revenue = income_stmt.get('Total Revenue')
+        rev_yoy = revenue.pct_change(-1).iloc[0] if revenue is not None and len(revenue) > 1 else np.nan
+
+        # --- Gross Margin ---
+        gross_profit = income_stmt.get('Gross Profit')
+        gm = (gross_profit / revenue).iloc[0] if gross_profit is not None and revenue is not None and not revenue.empty and revenue.iloc[0] != 0 else np.nan
+        gm_delta = (gm - (gross_profit / revenue).iloc[1]) if gross_profit is not None and revenue is not None and len(revenue) > 1 and not revenue.empty and revenue.iloc[1] != 0 else np.nan
+
+        # --- Operating Margin ---
+        operating_income = income_stmt.get('Operating Income')
+        om = (operating_income / revenue).iloc[0] if operating_income is not None and revenue is not None and not revenue.empty and revenue.iloc[0] != 0 else np.nan
+        om_delta = (om - (operating_income / revenue).iloc[1]) if operating_income is not None and revenue is not None and len(revenue) > 1 and not revenue.empty and revenue.iloc[1] != 0 else np.nan
+
+        # --- FCF Margin ---
+        cfo = cash_flow.get('Cash Flow From Operations')
+        capex = cash_flow.get('Capital Expenditures') # This might be negative in yfinance
+        
+        # Ensure capex is treated as a positive cost for FCF calculation
+        if capex is not None:
+            capex = capex.abs()
+
+        fcf = cfo + capex if cfo is not None and capex is not None else None # FCF = CFO - CapEx (CapEx is usually negative in yfinance)
+        fcf_margin = (fcf / revenue).iloc[0] if fcf is not None and revenue is not None and not revenue.empty and revenue.iloc[0] != 0 else np.nan
+        fcf_delta = (fcf_margin - (fcf / revenue).iloc[1]) if fcf is not None and revenue is not None and len(revenue) > 1 and not revenue.empty and revenue.iloc[1] != 0 else np.nan
+
+        # --- Accruals Proxy: (NetIncome − CFO)/AvgAssets ---
+        net_income = income_stmt.get('Net Income')
+        total_assets = balance_sheet.get('Total Assets')
+
+        if net_income is not None and cfo is not None and total_assets is not None and len(total_assets) > 1:
+            avg_assets = (total_assets.iloc[0] + total_assets.iloc[1]) / 2
+            if avg_assets != 0:
+                accruals_proxy = (net_income.iloc[0] - cfo.iloc[0]) / avg_assets
+            else:
+                accruals_proxy = np.nan
+        else:
+            accruals_proxy = np.nan
+
+        return {
+            'rev_yoy': rev_yoy,
+            'gm': gm, 'gm_delta': gm_delta,
+            'om': om, 'om_delta': om_delta,
+            'fcf_margin': fcf_margin, 'fcf_delta': fcf_delta,
+            'accruals_proxy': accruals_proxy
+        }
+
+    except Exception as e:
+        print(f"Error fetching fundamentals for {ticker}: {e}")
+        return {
+            'rev_yoy': np.nan,
+            'gm': np.nan, 'gm_delta': np.nan,
+            'om': np.nan, 'om_delta': np.nan,
+            'fcf_margin': np.nan, 'fcf_delta': np.nan,
+            'accruals_proxy': np.nan
+        }

--- a/tests/growthbrief/test_fundamentals.py
+++ b/tests/growthbrief/test_fundamentals.py
@@ -1,0 +1,125 @@
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import Mock, patch
+from growthbrief.features.fundamentals import fundamentals_snapshot
+
+# Fixture for a mock yfinance Ticker object with complete data
+@pytest.fixture
+def mock_ticker_complete():
+    mock_income_stmt = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Total Revenue': 1000, 'Gross Profit': 400, 'Operating Income': 200, 'Net Income': 150},
+        pd.to_datetime('2023-12-31'): {'Total Revenue': 900, 'Gross Profit': 350, 'Operating Income': 180, 'Net Income': 130},
+    })
+    mock_cash_flow = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Cash Flow From Operations': 180, 'Capital Expenditures': -50},
+        pd.to_datetime('2023-12-31'): {'Cash Flow From Operations': 160, 'Capital Expenditures': -40},
+    })
+    mock_balance_sheet = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Total Assets': 1000},
+        pd.to_datetime('2023-12-31'): {'Total Assets': 900},
+    })
+
+    mock_stock = Mock()
+    mock_stock.financials = mock_income_stmt
+    mock_stock.cashflow = mock_cash_flow
+    mock_stock.balance_sheet = mock_balance_sheet
+    return mock_stock
+
+# Fixture for a mock yfinance Ticker object with missing data
+@pytest.fixture
+def mock_ticker_missing_data():
+    mock_income_stmt = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Total Revenue': 1000},
+    })
+    mock_cash_flow = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Cash Flow From Operations': 180},
+    })
+    mock_balance_sheet = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Total Assets': 1000},
+    })
+
+    mock_stock = Mock()
+    mock_stock.financials = mock_income_stmt
+    mock_stock.cashflow = mock_cash_flow
+    mock_stock.balance_sheet = mock_balance_sheet
+    return mock_stock
+
+# Fixture for a mock yfinance Ticker object with empty dataframes
+@pytest.fixture
+def mock_ticker_empty_data():
+    mock_stock = Mock()
+    mock_stock.financials = pd.DataFrame()
+    mock_stock.cashflow = pd.DataFrame()
+    mock_stock.balance_sheet = pd.DataFrame()
+    return mock_stock
+
+@patch('yfinance.Ticker')
+def test_fundamentals_snapshot_complete_data(mock_yf_ticker, mock_ticker_complete):
+    mock_yf_ticker.return_value = mock_ticker_complete
+    result = fundamentals_snapshot("AAPL")
+
+    assert isinstance(result, dict)
+    assert 'rev_yoy' in result
+    assert 'gm' in result
+    assert 'gm_delta' in result
+    assert 'om' in result
+    assert 'om_delta' in result
+    assert 'fcf_margin' in result
+    assert 'fcf_delta' in result
+    assert 'accruals_proxy' in result
+
+    # Basic assertions for calculated values (approximate due to float precision)
+    assert np.isclose(result['rev_yoy'], (1000-900)/900)
+    assert np.isclose(result['gm'], 400/1000)
+    assert np.isclose(result['gm_delta'], (400/1000) - (350/900))
+    assert np.isclose(result['om'], 200/1000)
+    assert np.isclose(result['om_delta'], (200/1000) - (180/900))
+    
+    # FCF = CFO - CapEx (CapEx is negative in yfinance, so CFO + CapEx)
+    fcf_current = 180 + (-50)
+    fcf_prev = 160 + (-40)
+    assert np.isclose(result['fcf_margin'], fcf_current / 1000)
+    assert np.isclose(result['fcf_delta'], (fcf_current / 1000) - (fcf_prev / 900))
+
+    # Accruals proxy: (NetIncome − CFO)/AvgAssets
+    net_income_current = 150
+    cfo_current = 180
+    avg_assets = (1000 + 900) / 2
+    assert np.isclose(result['accruals_proxy'], (net_income_current - cfo_current) / avg_assets)
+
+@patch('yfinance.Ticker')
+def test_fundamentals_snapshot_missing_data(mock_yf_ticker, mock_ticker_missing_data):
+    mock_yf_ticker.return_value = mock_ticker_missing_data
+    result = fundamentals_snapshot("MSFT")
+
+    # All values should be NaN if data is insufficient for calculation
+    assert np.isnan(result['rev_yoy'])
+    assert np.isnan(result['gm_delta'])
+    assert np.isnan(result['om_delta'])
+    assert np.isnan(result['fcf_delta'])
+    assert np.isnan(result['accruals_proxy'])
+
+@patch('yfinance.Ticker')
+def test_fundamentals_snapshot_empty_data(mock_yf_ticker, mock_ticker_empty_data):
+    mock_yf_ticker.return_value = mock_ticker_empty_data
+    result = fundamentals_snapshot("GOOG")
+
+    # All values should be NaN if dataframes are empty
+    assert np.isnan(result['rev_yoy'])
+    assert np.isnan(result['gm'])
+    assert np.isnan(result['om'])
+    assert np.isnan(result['fcf_margin'])
+    assert np.isnan(result['accruals_proxy'])
+
+@patch('yfinance.Ticker')
+def test_fundamentals_snapshot_exception_handling(mock_yf_ticker):
+    mock_yf_ticker.side_effect = Exception("Network error")
+    result = fundamentals_snapshot("AMZN")
+
+    # All values should be NaN on exception
+    assert np.isnan(result['rev_yoy'])
+    assert np.isnan(result['gm'])
+    assert np.isnan(result['om'])
+    assert np.isnan(result['fcf_margin'])
+    assert np.isnan(result['accruals_proxy'])


### PR DESCRIPTION
What changed + why: Implemented `fundamentals_snapshot` function to fetch key fundamental data using `yfinance`. This includes revenue YoY, gross/operating/FCF margins, and accruals proxy.\nAcceptance checks:\n- `src/growthbrief/features/fundamentals.py` created.\n- `tests/growthbrief/test_fundamentals.py` created with unit tests for happy path, missing data, and exception handling.\nTODOs: None for this step.