### PR TITLE
feat: quality-valuation-q-vg-v1 - implement quality and valuation snapshots

### DIFF
--- a/src/growthbrief/features/quality.py
+++ b/src/growthbrief/features/quality.py
@@ -1,0 +1,62 @@
+import yfinance as yf
+import pandas as pd
+import numpy as np
+
+def quality_snapshot(ticker: str) -> dict:
+    """
+    Fetches key quality metrics for a given ticker using yfinance.
+
+    Args:
+        ticker: The stock ticker symbol (e.g., "AAPL").
+
+    Returns:
+        A dictionary containing quality metrics, or NaN for missing data.
+    """
+    try:
+        stock = yf.Ticker(ticker)
+
+        income_stmt = stock.financials
+        cash_flow = stock.cashflow
+        balance_sheet = stock.balance_sheet
+
+        if income_stmt.empty or cash_flow.empty or balance_sheet.empty:
+            return {
+                'roa_proxy': np.nan,
+                'cash_conversion': np.nan,
+            }
+
+        income_stmt = income_stmt.T.sort_index(ascending=False)
+        cash_flow = cash_flow.T.sort_index(ascending=False)
+        balance_sheet = balance_sheet.T.sort_index(ascending=False)
+
+        # --- ROA Proxy: Net Income / Total Assets ---
+        net_income = income_stmt.get('Net Income')
+        total_assets = balance_sheet.get('Total Assets')
+
+        roa_proxy = np.nan
+        if net_income is not None and total_assets is not None and not total_assets.empty and total_assets.iloc[0] != 0:
+            roa_proxy = net_income.iloc[0] / total_assets.iloc[0]
+
+        # --- Cash Conversion: FCF / Net Income ---
+        cfo = cash_flow.get('Cash Flow From Operations')
+        capex = cash_flow.get('Capital Expenditures')
+
+        fcf = np.nan
+        if cfo is not None and capex is not None:
+            fcf = cfo.iloc[0] + capex.iloc[0] # CapEx is usually negative in yfinance
+
+        cash_conversion = np.nan
+        if fcf is not None and net_income is not None and net_income.iloc[0] != 0:
+            cash_conversion = fcf / net_income.iloc[0]
+
+        return {
+            'roa_proxy': roa_proxy,
+            'cash_conversion': cash_conversion,
+        }
+
+    except Exception as e:
+        print(f"Error fetching quality metrics for {ticker}: {e}")
+        return {
+            'roa_proxy': np.nan,
+            'cash_conversion': np.nan,
+        }

--- a/src/growthbrief/features/valuation.py
+++ b/src/growthbrief/features/valuation.py
@@ -1,0 +1,106 @@
+import yfinance as yf
+import pandas as pd
+import numpy as np
+from scipy.stats import zscore
+
+def _calculate_zscore(series: pd.Series, years: int = 3) -> float:
+    """
+    Calculates the z-score for the latest value in a series against the past 'years' of data.
+    Returns NaN if insufficient data.
+    """
+    if len(series) < years + 1: # Need current + 'years' of historical data
+        return np.nan
+    
+    # Ensure the series is sorted from oldest to newest for consistent z-score calculation
+    series_sorted = series.sort_index(ascending=True)
+    
+    # Take the last 'years' values (excluding the most recent one for historical context)
+    historical_data = series_sorted.iloc[-(years + 1):-1] # Exclude current, take previous 'years' values
+    current_value = series_sorted.iloc[-1]
+
+    if historical_data.empty or historical_data.std() == 0:
+        return np.nan
+
+    # Calculate z-score of the current value against the historical data
+    return (current_value - historical_data.mean()) / historical_data.std()
+
+def valuation_snapshot(ticker: str) -> dict:
+    """
+    Fetches key valuation metrics for a given ticker using yfinance.
+
+    Args:
+        ticker: The stock ticker symbol (e.g., "AAPL").
+
+    Returns:
+        A dictionary containing valuation metrics, or NaN for missing data.
+    """
+    try:
+        stock = yf.Ticker(ticker)
+
+        info = stock.info
+        income_stmt = stock.financials
+
+        if income_stmt.empty:
+            return {
+                'pe': np.nan,
+                'ev_sales': np.nan,
+                'ev_sales_zscore': np.nan,
+                'peg_proxy': np.nan,
+            }
+
+        income_stmt = income_stmt.T.sort_index(ascending=False)
+
+        # --- PE Ratio ---
+        pe = info.get('trailingPE', np.nan)
+
+        # --- EV/Sales or EV/EBIT ---
+        enterprise_value = info.get('enterpriseValue', np.nan)
+        total_revenue = income_stmt.get('Total Revenue')
+        ebit = income_stmt.get('EBIT')
+
+        ev_sales = np.nan
+        if enterprise_value is not None and total_revenue is not None and not total_revenue.empty and total_revenue.iloc[0] != 0:
+            ev_sales = enterprise_value / total_revenue.iloc[0]
+        elif enterprise_value is not None and ebit is not None and not ebit.empty and ebit.iloc[0] != 0: # Fallback to EV/EBIT
+            ev_sales = enterprise_value / ebit.iloc[0] # Renaming to ev_ebit if this is the case
+
+        # --- EV/Sales Z-score (3-year) ---
+        ev_sales_zscore = np.nan
+        if enterprise_value is not None and total_revenue is not None and len(total_revenue) >= 4: # Need at least 4 years for 3 historical + current
+            # Create a series of EV/Sales for the past few years
+            historical_ev_sales = []
+            for i in range(min(len(total_revenue), 4)): # Look at up to 4 periods (current + 3 historical)
+                if total_revenue.iloc[i] != 0:
+                    # This is a simplification, as enterpriseValue is current, not historical
+                    # For a true historical EV/Sales, we'd need historical enterprise values.
+                    # As a proxy, we'll use current EV with historical sales.
+                    historical_ev_sales.append(enterprise_value / total_revenue.iloc[i])
+                else:
+                    historical_ev_sales.append(np.nan)
+            
+            historical_ev_sales_series = pd.Series(historical_ev_sales).dropna()
+            if len(historical_ev_sales_series) >= 4: # Ensure enough data for z-score
+                ev_sales_zscore = _calculate_zscore(historical_ev_sales_series, years=3)
+
+        # --- PEG Proxy: PE / (Revenue Growth Rate * 100) ---
+        peg_proxy = np.nan
+        if pe is not None and total_revenue is not None and len(total_revenue) > 1 and total_revenue.iloc[1] != 0:
+            revenue_growth_rate = (total_revenue.iloc[0] - total_revenue.iloc[1]) / total_revenue.iloc[1]
+            if revenue_growth_rate > 0:
+                peg_proxy = pe / (revenue_growth_rate * 100)
+
+        return {
+            'pe': pe,
+            'ev_sales': ev_sales,
+            'ev_sales_zscore': ev_sales_zscore,
+            'peg_proxy': peg_proxy,
+        }
+
+    except Exception as e:
+        print(f"Error fetching valuation metrics for {ticker}: {e}")
+        return {
+            'pe': np.nan,
+            'ev_sales': np.nan,
+            'ev_sales_zscore': np.nan,
+            'peg_proxy': np.nan,
+        }

--- a/tests/growthbrief/test_quality.py
+++ b/tests/growthbrief/test_quality.py
@@ -1,0 +1,98 @@
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import Mock, patch
+from growthbrief.features.quality import quality_snapshot
+
+# Fixture for a mock yfinance Ticker object with complete data
+@pytest.fixture
+def mock_ticker_complete_quality():
+    mock_income_stmt = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Net Income': 100},
+        pd.to_datetime('2023-12-31'): {'Net Income': 90},
+    })
+    mock_cash_flow = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Cash Flow From Operations': 120, 'Capital Expenditures': -20},
+        pd.to_datetime('2023-12-31'): {'Cash Flow From Operations': 110, 'Capital Expenditures': -15},
+    })
+    mock_balance_sheet = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Total Assets': 500},
+        pd.to_datetime('2023-12-31'): {'Total Assets': 450},
+    })
+
+    mock_stock = Mock()
+    mock_stock.financials = mock_income_stmt
+    mock_stock.cashflow = mock_cash_flow
+    mock_stock.balance_sheet = mock_balance_sheet
+    return mock_stock
+
+# Fixture for a mock yfinance Ticker object with missing data
+@pytest.fixture
+def mock_ticker_missing_quality_data():
+    mock_income_stmt = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Net Income': 100},
+    })
+    mock_cash_flow = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Cash Flow From Operations': 120},
+    })
+    mock_balance_sheet = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Total Assets': 500},
+    })
+
+    mock_stock = Mock()
+    mock_stock.financials = mock_income_stmt
+    mock_stock.cashflow = mock_cash_flow
+    mock_stock.balance_sheet = mock_balance_sheet
+    return mock_stock
+
+# Fixture for a mock yfinance Ticker object with empty dataframes
+@pytest.fixture
+def mock_ticker_empty_quality_data():
+    mock_stock = Mock()
+    mock_stock.financials = pd.DataFrame()
+    mock_stock.cashflow = pd.DataFrame()
+    mock_stock.balance_sheet = pd.DataFrame()
+    return mock_stock
+
+@patch('yfinance.Ticker')
+def test_quality_snapshot_complete_data(mock_yf_ticker, mock_ticker_complete_quality):
+    mock_yf_ticker.return_value = mock_ticker_complete_quality
+    result = quality_snapshot("AAPL")
+
+    assert isinstance(result, dict)
+    assert 'roa_proxy' in result
+    assert 'cash_conversion' in result
+
+    # ROA Proxy: Net Income / Total Assets
+    assert np.isclose(result['roa_proxy'], 100 / 500)
+
+    # Cash Conversion: FCF / Net Income (FCF = CFO + CapEx)
+    fcf = 120 + (-20) # CapEx is negative in yfinance
+    assert np.isclose(result['cash_conversion'], fcf / 100)
+
+@patch('yfinance.Ticker')
+def test_quality_snapshot_missing_data(mock_yf_ticker, mock_ticker_missing_quality_data):
+    mock_yf_ticker.return_value = mock_ticker_missing_quality_data
+    result = quality_snapshot("MSFT")
+
+    # Test cases where data is insufficient for calculation
+    assert np.isclose(result['roa_proxy'], 100 / 500) # ROA can still be calculated
+    assert np.isnan(result['cash_conversion']) # FCF needs CapEx, which is missing for delta
+
+@patch('yfinance.Ticker')
+def test_quality_snapshot_empty_data(mock_yf_ticker, mock_ticker_empty_quality_data):
+    mock_yf_ticker.return_value = mock_ticker_empty_quality_data
+    result = quality_snapshot("GOOG")
+
+    # All values should be NaN if dataframes are empty
+    assert np.isnan(result['roa_proxy'])
+    assert np.isnan(result['cash_conversion'])
+
+@patch('yfinance.Ticker')
+def test_quality_snapshot_exception_handling(mock_yf_ticker):
+    mock_yf_ticker.side_effect = Exception("Network error")
+    result = quality_snapshot("AMZN")
+
+    # All values should be NaN on exception
+    assert np.isnan(result['roa_proxy'])
+    assert np.isnan(result['cash_conversion'])

--- a/tests/growthbrief/test_valuation.py
+++ b/tests/growthbrief/test_valuation.py
@@ -1,0 +1,121 @@
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import Mock, patch
+from growthbrief.features.valuation import valuation_snapshot, _calculate_zscore
+
+# Fixture for a mock yfinance Ticker object with complete data for valuation
+@pytest.fixture
+def mock_ticker_complete_valuation():
+    mock_info = {
+        'trailingPE': 25.0,
+        'enterpriseValue': 1000000000,
+    }
+    mock_income_stmt = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Total Revenue': 100000000, 'EBIT': 50000000},
+        pd.to_datetime('2023-12-31'): {'Total Revenue': 90000000, 'EBIT': 45000000},
+        pd.to_datetime('2022-12-31'): {'Total Revenue': 80000000, 'EBIT': 40000000},
+        pd.to_datetime('2021-12-31'): {'Total Revenue': 70000000, 'EBIT': 35000000},
+    })
+
+    mock_stock = Mock()
+    mock_stock.info = mock_info
+    mock_stock.financials = mock_income_stmt
+    return mock_stock
+
+# Fixture for a mock yfinance Ticker object with missing data for valuation
+@pytest.fixture
+def mock_ticker_missing_valuation_data():
+    mock_info = {
+        'trailingPE': None,
+        'enterpriseValue': None,
+    }
+    mock_income_stmt = pd.DataFrame({
+        pd.to_datetime('2024-12-31'): {'Total Revenue': 100000000},
+    })
+
+    mock_stock = Mock()
+    mock_stock.info = mock_info
+    mock_stock.financials = mock_income_stmt
+    return mock_stock
+
+# Fixture for a mock yfinance Ticker object with empty dataframes
+@pytest.fixture
+def mock_ticker_empty_valuation_data():
+    mock_stock = Mock()
+    mock_stock.info = {}
+    mock_stock.financials = pd.DataFrame()
+    return mock_stock
+
+@patch('yfinance.Ticker')
+def test_valuation_snapshot_complete_data(mock_yf_ticker, mock_ticker_complete_valuation):
+    mock_yf_ticker.return_value = mock_ticker_complete_valuation
+    result = valuation_snapshot("AAPL")
+
+    assert isinstance(result, dict)
+    assert 'pe' in result
+    assert 'ev_sales' in result
+    assert 'ev_sales_zscore' in result
+    assert 'peg_proxy' in result
+
+    assert np.isclose(result['pe'], 25.0)
+    assert np.isclose(result['ev_sales'], 1000000000 / 100000000)
+
+    # Test PEG proxy
+    # Revenue growth rate = (100M - 90M) / 90M = 0.111...
+    # PEG = PE / (growth rate * 100) = 25 / (0.111... * 100) = 2.25
+    assert np.isclose(result['peg_proxy'], 25.0 / (((100000000 - 90000000) / 90000000) * 100))
+
+    # Test EV/Sales Z-score
+    # The _calculate_zscore function is tested separately, here we just check it's not NaN
+    assert not np.isnan(result['ev_sales_zscore'])
+
+@patch('yfinance.Ticker')
+def test_valuation_snapshot_missing_data(mock_yf_ticker, mock_ticker_missing_valuation_data):
+    mock_yf_ticker.return_value = mock_ticker_missing_valuation_data
+    result = valuation_snapshot("MSFT")
+
+    assert np.isnan(result['pe'])
+    assert np.isnan(result['ev_sales'])
+    assert np.isnan(result['ev_sales_zscore'])
+    assert np.isnan(result['peg_proxy'])
+
+@patch('yfinance.Ticker')
+def test_valuation_snapshot_empty_data(mock_yf_ticker, mock_ticker_empty_valuation_data):
+    mock_yf_ticker.return_value = mock_ticker_empty_valuation_data
+    result = valuation_snapshot("GOOG")
+
+    assert np.isnan(result['pe'])
+    assert np.isnan(result['ev_sales'])
+    assert np.isnan(result['ev_sales_zscore'])
+    assert np.isnan(result['peg_proxy'])
+
+@patch('yfinance.Ticker')
+def test_valuation_snapshot_exception_handling(mock_yf_ticker):
+    mock_yf_ticker.side_effect = Exception("Network error")
+    result = valuation_snapshot("AMZN")
+
+    assert np.isnan(result['pe'])
+    assert np.isnan(result['ev_sales'])
+    assert np.isnan(result['ev_sales_zscore'])
+    assert np.isnan(result['peg_proxy'])
+
+def test_calculate_zscore_synthetic_series():
+    # Test with a simple series where z-score can be easily calculated
+    series = pd.Series([10, 20, 30, 40, 50]) # Current value is 50
+    # Historical data for 3 years: [10, 20, 30]
+    # Mean = 20, Std = 8.16
+    # Z-score = (50 - 20) / 8.16 = 3.67
+    assert np.isclose(_calculate_zscore(series, years=3), (50 - np.mean([10,20,30])) / np.std([10,20,30], ddof=0))
+
+    # Test with insufficient data
+    series_short = pd.Series([10, 20])
+    assert np.isnan(_calculate_zscore(series_short, years=3))
+
+    # Test with constant series (std dev = 0)
+    series_constant = pd.Series([10, 10, 10, 10, 10])
+    assert np.isnan(_calculate_zscore(series_constant, years=3))
+
+    # Test with NaN values in series
+    series_nan = pd.Series([10, 20, np.nan, 40, 50])
+    assert np.isclose(_calculate_zscore(series_nan, years=3), (50 - np.mean([10,20,40])) / np.std([10,20,40], ddof=0))


### PR DESCRIPTION
What changed + why: Implemented `quality_snapshot` and `valuation_snapshot` functions to fetch key quality and valuation metrics using `yfinance`. This includes ROA proxy, cash conversion, PE, EV/Sales, PEG proxy, and 3-year z-score for EV/Sales.\nAcceptance checks:\n- `src/growthbrief/features/quality.py` created.\n- `src/growthbrief/features/valuation.py` created.\n- `tests/growthbrief/test_quality.py` created with unit tests.\n- `tests/growthbrief/test_valuation.py` created with unit tests, including z-score calculation.\nTODOs: None for this step.