### PR TITLE
feat: industry-technical-it-tc-v1 - implement industry and technical snapshots

### DIFF
--- a/src/growthbrief/features/industry.py
+++ b/src/growthbrief/features/industry.py
@@ -1,0 +1,138 @@
+import yfinance as yf
+import pandas as pd
+import numpy as np
+
+# Simple mapping for common tickers to their sector ETFs
+# In a real application, this would be more robust (e.g., external data, industry classification)
+SECTOR_ETF_MAP = {
+    'AAPL': 'XLK',  # Technology Select Sector SPDR Fund
+    'MSFT': 'XLK',
+    'NVDA': 'SMH',  # VanEck Semiconductor ETF
+    'GOOG': 'XLK',
+    'AMZN': 'XLY',  # Consumer Discretionary Select Sector SPDR Fund
+    'META': 'XLC',  # Communication Services Select Sector SPDR Fund
+    'TSLA': 'XLY',
+    'JPM': 'XLF',  # Financial Select Sector SPDR Fund
+    'XOM': 'XLE',  # Energy Select Sector SPDR Fund
+    'JNJ': 'XLV',  # Health Care Select Sector SPDR Fund
+    'PG': 'XLP',  # Consumer Staples Select Sector SPDR Fund
+    'V': 'XLF',
+    'MA': 'XLF',
+    'UNH': 'XLV',
+    'HD': 'XLY',
+    'KO': 'XLP',
+    'PEP': 'XLP',
+    'DIS': 'XLC',
+    'CMCSA': 'XLC',
+    'VZ': 'XLC',
+    'T': 'XLC',
+    'PFE': 'XLV',
+    'MRK': 'XLV',
+    'ABBV': 'XLV',
+    'LLY': 'XLV',
+    'NKE': 'XLY',
+    'SBUX': 'XLY',
+    'MCD': 'XLY',
+    'BA': 'XLI',  # Industrial Select Sector SPDR Fund
+    'CAT': 'XLI',
+    'GE': 'XLI',
+    'HON': 'XLI',
+    'MMM': 'XLI',
+    'DOW': 'XLB',  # Materials Select Sector SPDR Fund
+    'DUK': 'XLU',  # Utilities Select Sector SPDR Fund
+    'NEE': 'XLU',
+    'SO': 'XLU',
+    'PLD': 'XLRE', # Real Estate Select Sector SPDR Fund
+    'SPG': 'XLRE',
+}
+
+def _calculate_momentum(series: pd.Series, months: int) -> float:
+    """
+    Calculates the momentum (percentage change) over a given number of months.
+    """
+    if len(series) < months * 21: # Approx 21 trading days per month
+        return np.nan
+    
+    start_price = series.iloc[-(months * 21)]
+    end_price = series.iloc[-1]
+    return (end_price - start_price) / start_price
+
+def _calculate_sma(series: pd.Series, window: int) -> float:
+    """
+    Calculates the Simple Moving Average (SMA).
+    """
+    if len(series) < window:
+        return np.nan
+    return series.iloc[-window:].mean()
+
+def industry_snapshot(ticker: str) -> dict:
+    """
+    Fetches industry tailwind metrics for a given ticker.
+
+    Args:
+        ticker: The stock ticker symbol (e.g., "AAPL").
+
+    Returns:
+        A dictionary containing industry metrics, or NaN for missing data.
+    """
+    sector_etf_symbol = SECTOR_ETF_MAP.get(ticker.upper())
+    if not sector_etf_symbol:
+        print(f"Warning: No sector ETF mapping found for {ticker}")
+        return {
+            'sector_rs_6m': np.nan,
+            'sector_rs_12m': np.nan,
+            'sector_above_50dma': np.nan,
+            'sector_above_200dma': np.nan,
+        }
+
+    try:
+        # Fetch historical data for sector ETF and SPY
+        # Fetch enough data for 12 months + 200-day SMA (approx 252 trading days/year)
+        end_date = pd.Timestamp.now()
+        start_date = end_date - pd.DateOffset(years=1, months=3) # 15 months to be safe
+
+        sector_etf_data = yf.download(sector_etf_symbol, start=start_date, end=end_date, progress=False)
+        spy_data = yf.download('SPY', start=start_date, end=end_date, progress=False)
+
+        if sector_etf_data.empty or spy_data.empty:
+            return {
+                'sector_rs_6m': np.nan,
+                'sector_rs_12m': np.nan,
+                'sector_above_50dma': np.nan,
+                'sector_above_200dma': np.nan,
+            }
+
+        sector_etf_close = sector_etf_data['Adj Close']
+        spy_close = spy_data['Adj Close']
+
+        # --- Relative Strength vs SPY ---
+        sector_6m_mom = _calculate_momentum(sector_etf_close, 6)
+        spy_6m_mom = _calculate_momentum(spy_close, 6)
+        sector_rs_6m = sector_6m_mom - spy_6m_mom if not np.isnan(sector_6m_mom) and not np.isnan(spy_6m_mom) else np.nan
+
+        sector_12m_mom = _calculate_momentum(sector_etf_close, 12)
+        spy_12m_mom = _calculate_momentum(spy_close, 12)
+        sector_rs_12m = sector_12m_mom - spy_12m_mom if not np.isnan(sector_12m_mom) and not np.isnan(spy_12m_mom) else np.nan
+
+        # --- Industry Breadth (proxy with ETF price vs SMAs) ---
+        sector_etf_50dma = _calculate_sma(sector_etf_close, 50)
+        sector_etf_200dma = _calculate_sma(sector_etf_close, 200)
+
+        sector_above_50dma = 1.0 if sector_etf_close.iloc[-1] > sector_etf_50dma else 0.0 if not np.isnan(sector_etf_50dma) else np.nan
+        sector_above_200dma = 1.0 if sector_etf_close.iloc[-1] > sector_etf_200dma else 0.0 if not np.isnan(sector_etf_200dma) else np.nan
+
+        return {
+            'sector_rs_6m': sector_rs_6m,
+            'sector_rs_12m': sector_rs_12m,
+            'sector_above_50dma': sector_above_50dma,
+            'sector_above_200dma': sector_above_200dma,
+        }
+
+    except Exception as e:
+        print(f"Error fetching industry metrics for {ticker}: {e}")
+        return {
+            'sector_rs_6m': np.nan,
+            'sector_rs_12m': np.nan,
+            'sector_above_50dma': np.nan,
+            'sector_above_200dma': np.nan,
+        }

--- a/src/growthbrief/features/technical.py
+++ b/src/growthbrief/features/technical.py
@@ -1,0 +1,105 @@
+import yfinance as yf
+import pandas as pd
+import numpy as np
+
+def _calculate_momentum(series: pd.Series, months: int) -> float:
+    """
+    Calculates the momentum (percentage change) over a given number of months.
+    """
+    if len(series) < months * 21: # Approx 21 trading days per month
+        return np.nan
+    
+    start_price = series.iloc[-(months * 21)]
+    end_price = series.iloc[-1]
+    return (end_price - start_price) / start_price
+
+def _calculate_sma(series: pd.Series, window: int) -> float:
+    """
+    Calculates the Simple Moving Average (SMA).
+    """
+    if len(series) < window:
+        return np.nan
+    return series.iloc[-window:].mean()
+
+def _calculate_max_drawdown(series: pd.Series) -> float:
+    """
+    Calculates the maximum drawdown of a price series.
+    """
+    if series.empty:
+        return np.nan
+    
+    # Calculate the running maximum
+    running_max = series.cummax()
+    # Calculate the drawdown
+    drawdown = (series - running_max) / running_max
+    # Return the maximum drawdown (most negative value)
+    return drawdown.min()
+
+def technical_snapshot(ticker: str) -> dict:
+    """
+    Fetches key technical indicators for a given ticker.
+
+    Args:
+        ticker: The stock ticker symbol (e.g., "AAPL").
+
+    Returns:
+        A dictionary containing technical metrics, or NaN for missing data.
+    """
+    try:
+        stock = yf.Ticker(ticker)
+
+        # Fetch enough data for 200-day SMA (approx 252 trading days/year) + 6 months momentum
+        end_date = pd.Timestamp.now()
+        start_date = end_date - pd.DateOffset(years=1, months=3) # 15 months to be safe
+
+        hist = stock.history(start=start_date, end=end_date)
+
+        if hist.empty:
+            return {
+                'above_50dma': np.nan,
+                'above_100dma': np.nan,
+                'above_200dma': np.nan,
+                '6m_momentum': np.nan,
+                'max_drawdown_1y': np.nan,
+            }
+
+        close_prices = hist['Close']
+
+        # --- Above 50/100/200-DMA ---
+        current_price = close_prices.iloc[-1]
+
+        sma_50 = _calculate_sma(close_prices, 50)
+        above_50dma = 1.0 if current_price > sma_50 else 0.0 if not np.isnan(sma_50) else np.nan
+
+        sma_100 = _calculate_sma(close_prices, 100)
+        above_100dma = 1.0 if current_price > sma_100 else 0.0 if not np.isnan(sma_100) else np.nan
+
+        sma_200 = _calculate_sma(close_prices, 200)
+        above_200dma = 1.0 if current_price > sma_200 else 0.0 if not np.isnan(sma_200) else np.nan
+
+        # --- 6m momentum ---
+        six_m_momentum = _calculate_momentum(close_prices, 6)
+
+        # --- Drawdown filter (e.g., max drawdown over last year) ---
+        # Fetch data for 1 year for drawdown calculation
+        drawdown_start_date = end_date - pd.DateOffset(years=1)
+        drawdown_hist = stock.history(start=drawdown_start_date, end=end_date)
+        max_drawdown_1y = _calculate_max_drawdown(drawdown_hist['Close'])
+
+        return {
+            'above_50dma': above_50dma,
+            'above_100dma': above_100dma,
+            'above_200dma': above_200dma,
+            '6m_momentum': six_m_momentum,
+            'max_drawdown_1y': max_drawdown_1y,
+        }
+
+    except Exception as e:
+        print(f"Error fetching technical metrics for {ticker}: {e}")
+        return {
+            'above_50dma': np.nan,
+            'above_100dma': np.nan,
+            'above_200dma': np.nan,
+            '6m_momentum': np.nan,
+            'max_drawdown_1y': np.nan,
+        }

--- a/tests/growthbrief/test_industry.py
+++ b/tests/growthbrief/test_industry.py
@@ -1,0 +1,96 @@
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import Mock, patch
+from growthbrief.features.industry import industry_snapshot, SECTOR_ETF_MAP
+
+# Fixture for a mock yfinance.download with complete data
+@pytest.fixture
+def mock_yf_download_complete():
+    def _mock_download(symbol, start, end, progress):
+        dates = pd.date_range(end=end, periods=300, freq='D') # Enough data for 200-day SMA
+        if symbol == 'SPY':
+            data = pd.DataFrame({'Adj Close': np.linspace(100, 110, 300)}, index=dates)
+        else: # Sector ETF
+            data = pd.DataFrame({'Adj Close': np.linspace(105, 115, 300)}, index=dates)
+        return data
+    return _mock_download
+
+# Fixture for a mock yfinance.download with insufficient data
+@pytest.fixture
+def mock_yf_download_insufficient():
+    def _mock_download(symbol, start, end, progress):
+        dates = pd.date_range(end=end, periods=10, freq='D') # Not enough for 6m momentum or SMAs
+        data = pd.DataFrame({'Adj Close': np.linspace(100, 105, 10)}, index=dates)
+        return data
+    return _mock_download
+
+# Fixture for a mock yfinance.download with empty data
+@pytest.fixture
+def mock_yf_download_empty():
+    def _mock_download(symbol, start, end, progress):
+        return pd.DataFrame()
+    return _mock_download
+
+@patch('yfinance.download')
+def test_industry_snapshot_complete_data(mock_download, mock_yf_download_complete):
+    mock_download.side_effect = mock_yf_download_complete
+    
+    # Test with a ticker that has a mapping
+    ticker = "AAPL"
+    result = industry_snapshot(ticker)
+
+    assert isinstance(result, dict)
+    assert 'sector_rs_6m' in result
+    assert 'sector_rs_12m' in result
+    assert 'sector_above_50dma' in result
+    assert 'sector_above_200dma' in result
+
+    # Basic checks that values are not NaN
+    assert not np.isnan(result['sector_rs_6m'])
+    assert not np.isnan(result['sector_rs_12m'])
+    assert result['sector_above_50dma'] in [0.0, 1.0]
+    assert result['sector_above_200dma'] in [0.0, 1.0]
+
+@patch('yfinance.download')
+def test_industry_snapshot_no_etf_mapping(mock_download):
+    result = industry_snapshot("UNKNOWN")
+
+    # All values should be NaN if no ETF mapping
+    assert np.isnan(result['sector_rs_6m'])
+    assert np.isnan(result['sector_rs_12m'])
+    assert np.isnan(result['sector_above_50dma'])
+    assert np.isnan(result['sector_above_200dma'])
+
+@patch('yfinance.download')
+def test_industry_snapshot_insufficient_data(mock_download, mock_yf_download_insufficient):
+    mock_download.side_effect = mock_yf_download_insufficient
+    result = industry_snapshot("AAPL")
+
+    # Values requiring sufficient historical data should be NaN
+    assert np.isnan(result['sector_rs_6m'])
+    assert np.isnan(result['sector_rs_12m'])
+    assert np.isnan(result['sector_above_50dma'])
+    assert np.isnan(result['sector_above_200dma'])
+
+@patch('yfinance.download')
+def test_industry_snapshot_empty_data(mock_download, mock_yf_download_empty):
+    mock_download.side_effect = mock_yf_download_empty
+    result = industry_snapshot("AAPL")
+
+    # All values should be NaN if dataframes are empty
+    assert np.isnan(result['sector_rs_6m'])
+    assert np.isnan(result['sector_rs_12m'])
+    assert np.isnan(result['sector_above_50dma'])
+    assert np.isnan(result['sector_above_200dma'])
+
+@patch('yfinance.download')
+def test_industry_snapshot_exception_handling(mock_download):
+    mock_download.side_effect = Exception("Network error")
+    result = industry_snapshot("AAPL")
+
+    # All values should be NaN on exception
+    assert np.isnan(result['sector_rs_6m'])
+    assert np.isnan(result['sector_rs_12m'])
+    assert np.isnan(result['sector_above_50dma'])
+    assert np.isnan(result['sector_above_200dma'])

--- a/tests/growthbrief/test_technical.py
+++ b/tests/growthbrief/test_technical.py
@@ -1,0 +1,97 @@
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import Mock, patch
+from growthbrief.features.technical import technical_snapshot, _calculate_max_drawdown
+
+# Fixture for a mock yfinance Ticker object with complete historical data
+@pytest.fixture
+def mock_ticker_complete_technical():
+    dates = pd.date_range(end=pd.Timestamp.now(), periods=300, freq='D') # Enough data for 200-day SMA
+    data = pd.DataFrame({'Close': np.linspace(100, 150, 300)}, index=dates)
+    mock_stock = Mock()
+    mock_stock.history.return_value = data
+    return mock_stock
+
+# Fixture for a mock yfinance Ticker object with insufficient historical data
+@pytest.fixture
+def mock_ticker_insufficient_technical_data():
+    dates = pd.date_range(end=pd.Timestamp.now(), periods=10, freq='D') # Not enough for SMAs or momentum
+    data = pd.DataFrame({'Close': np.linspace(100, 105, 10)}, index=dates)
+    mock_stock = Mock()
+    mock_stock.history.return_value = data
+    return mock_stock
+
+# Fixture for a mock yfinance Ticker object with empty historical data
+@pytest.fixture
+def mock_ticker_empty_technical_data():
+    mock_stock = Mock()
+    mock_stock.history.return_value = pd.DataFrame()
+    return mock_stock
+
+@patch('yfinance.Ticker')
+def test_technical_snapshot_complete_data(mock_yf_ticker, mock_ticker_complete_technical):
+    mock_yf_ticker.return_value = mock_ticker_complete_technical
+    result = technical_snapshot("AAPL")
+
+    assert isinstance(result, dict)
+    assert 'above_50dma' in result
+    assert 'above_100dma' in result
+    assert 'above_200dma' in result
+    assert '6m_momentum' in result
+    assert 'max_drawdown_1y' in result
+
+    # Basic checks that values are not NaN
+    assert result['above_50dma'] in [0.0, 1.0]
+    assert result['above_100dma'] in [0.0, 1.0]
+    assert result['above_200dma'] in [0.0, 1.0]
+    assert not np.isnan(result['6m_momentum'])
+    assert not np.isnan(result['max_drawdown_1y'])
+
+@patch('yfinance.Ticker')
+def test_technical_snapshot_insufficient_data(mock_yf_ticker, mock_ticker_insufficient_technical_data):
+    mock_yf_ticker.return_value = mock_ticker_insufficient_technical_data
+    result = technical_snapshot("MSFT")
+
+    # Values requiring sufficient historical data should be NaN
+    assert np.isnan(result['above_50dma'])
+    assert np.isnan(result['above_100dma'])
+    assert np.isnan(result['above_200dma'])
+    assert np.isnan(result['6m_momentum'])
+    assert np.isnan(result['max_drawdown_1y'])
+
+@patch('yfinance.Ticker')
+def test_technical_snapshot_empty_data(mock_yf_ticker, mock_ticker_empty_technical_data):
+    mock_yf_ticker.return_value = mock_ticker_empty_technical_data
+    result = technical_snapshot("GOOG")
+
+    # All values should be NaN if dataframes are empty
+    assert np.isnan(result['above_50dma'])
+    assert np.isnan(result['above_100dma'])
+    assert np.isnan(result['above_200dma'])
+    assert np.isnan(result['6m_momentum'])
+    assert np.isnan(result['max_drawdown_1y'])
+
+@patch('yfinance.Ticker')
+def test_technical_snapshot_exception_handling(mock_yf_ticker):
+    mock_yf_ticker.side_effect = Exception("Network error")
+    result = technical_snapshot("AMZN")
+
+    # All values should be NaN on exception
+    assert np.isnan(result['above_50dma'])
+    assert np.isnan(result['above_100dma'])
+    assert np.isnan(result['above_200dma'])
+    assert np.isnan(result['6m_momentum'])
+    assert np.isnan(result['max_drawdown_1y'])
+
+def test_calculate_max_drawdown_synthetic_series():
+    series = pd.Series([100, 90, 110, 80, 120])
+    # Drawdowns: (90-100)/100 = -0.1, (110-100)/100 = 0.1, (80-110)/110 = -0.27, (120-120)/120 = 0
+    # Max drawdown should be from 110 to 80, which is (80-110)/110 = -0.2727
+    assert np.isclose(_calculate_max_drawdown(series), (80-110)/110)
+
+    series_no_drawdown = pd.Series([100, 110, 120, 130])
+    assert np.isclose(_calculate_max_drawdown(series_no_drawdown), 0.0)
+
+    series_empty = pd.Series([])
+    assert np.isnan(_calculate_max_drawdown(series_empty))


### PR DESCRIPTION
What changed + why: Implemented `industry_snapshot` and `technical_snapshot` functions to fetch industry tailwind and technical confirmation metrics using `yfinance`. This includes sector relative strength, price vs SMAs, 6-month momentum, and max drawdown.\nAcceptance checks:\n- `src/growthbrief/features/industry.py` created.\n- `src/growthbrief/features/technical.py` created.\n- `tests/growthbrief/test_industry.py` created with unit tests.\n- `tests/growthbrief/test_technical.py` created with unit tests.\nTODOs: None for this step.