### PR TITLE
feat: leadership-confidence-stub - implement leadership confidence stub

### DIFF
--- a/src/growthbrief/features/leadership.py
+++ b/src/growthbrief/features/leadership.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+def leadership_confidence_from_text(text: str) -> float:
+    """
+    Stub function to assess leadership confidence from text.
+    
+    Args:
+        text: Input text (e.g., earnings call transcript, news article).
+        
+    Returns:
+        A float between 0 and 10 representing leadership confidence.
+    """
+    # TODO: Implement actual NLP/LLM logic here based on rubric:
+    # Rubric placeholders:
+    # - Capital allocation strategy (e.g., clear, consistent, value-accretive)
+    # - Guidance credibility (e.g., consistent achievement, realistic projections)
+    # - Adaptability to market changes
+    # - Communication clarity and transparency
+    # - Track record of execution
+
+    # For now, return a placeholder value or a simple heuristic
+    if "strong growth" in text.lower() or "exceed expectations" in text.lower():
+        return 8.0
+    elif "challenging environment" in text.lower() or "headwinds" in text.lower():
+        return 3.0
+    else:
+        return 5.0 # Neutral

--- a/tests/growthbrief/test_leadership.py
+++ b/tests/growthbrief/test_leadership.py
@@ -1,0 +1,23 @@
+import pytest
+from growthbrief.features.leadership import leadership_confidence_from_text
+
+def test_leadership_confidence_from_text_positive():
+    text = "The company showed strong growth and is expected to exceed expectations."
+    assert leadership_confidence_from_text(text) == 8.0
+
+def test_leadership_confidence_from_text_negative():
+    text = "The company is facing a challenging environment with significant headwinds."
+    assert leadership_confidence_from_text(text) == 3.0
+
+def test_leadership_confidence_from_text_neutral():
+    text = "The company provided an update on its operations."
+    assert leadership_confidence_from_text(text) == 5.0
+
+def test_leadership_confidence_from_text_case_insensitivity():
+    text = "STRONG GROWTH and EXCEED EXPECTATIONS."
+    assert leadership_confidence_from_text(text) == 8.0
+
+def test_leadership_confidence_from_text_determinism():
+    text1 = "This is a test with strong growth."
+    text2 = "This is a test with strong growth."
+    assert leadership_confidence_from_text(text1) == leadership_confidence_from_text(text2)


### PR DESCRIPTION
What changed + why: Implemented `leadership_confidence_from_text` stub function with rubric placeholders.\nAcceptance checks:\n- `src/growthbrief/features/leadership.py` created.\n- `tests/growthbrief/test_leadership.py` created with unit tests.\nTODOs: Implement actual NLP/LLM logic for leadership confidence assessment.